### PR TITLE
半空間を塗りつぶす

### DIFF
--- a/BSH-Siv3D/BSH-Siv3D.vcxproj
+++ b/BSH-Siv3D/BSH-Siv3D.vcxproj
@@ -114,6 +114,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Boundary.cpp" />
+    <ClCompile Include="HalfSpace.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="SamplePoint.cpp" />
     <ClCompile Include="State.cpp" />
@@ -317,6 +318,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Boundary.hpp" />
+    <ClInclude Include="HalfSpace.hpp" />
     <ClInclude Include="SamplePoint.hpp" />
     <ClInclude Include="State.h" />
     <ClInclude Include="stdafx.h" />

--- a/BSH-Siv3D/BSH-Siv3D.vcxproj.filters
+++ b/BSH-Siv3D/BSH-Siv3D.vcxproj.filters
@@ -153,6 +153,9 @@
     <ClCompile Include="State.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="HalfSpace.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="App\icon.ico">
@@ -792,6 +795,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="State.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="HalfSpace.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/BSH-Siv3D/Boundary.cpp
+++ b/BSH-Siv3D/Boundary.cpp
@@ -2,9 +2,24 @@
 
 # include "Boundary.hpp"
 
-Boundary::Boundary(Line const line)
+Boundary::Boundary(Vec2 begin, Vec2 end, Vec2 sceneSize)
 {
-	m_line = line;
+	if (begin.x == end.x)
+	{
+		m_line = Line(begin.x, 0, end.x, sceneSize.y);
+	}
+	else
+	{
+		Rect rect(0, 0, sceneSize.x, sceneSize.y);
+		Vec2 b(0, -begin.x * (end - begin).y / (end - begin).x + begin.y);
+		Vec2 e(sceneSize.x, (sceneSize.x + 1.f -begin.x) * (end - begin).y / (end - begin).x + begin.y);
+		Line longLine(b, e);
+		if (const auto points = rect.intersectsAt(longLine))
+		{
+			rect.draw(Palette::Skyblue);
+			m_line = Line(points.value()[0], points.value()[1]);
+		}
+	}
 	m_color = RandomColor();
 }
 

--- a/BSH-Siv3D/Boundary.cpp
+++ b/BSH-Siv3D/Boundary.cpp
@@ -1,13 +1,11 @@
 ﻿# include <Siv3D.hpp>
 
 # include "Boundary.hpp"
-# include "SamplePoint.hpp"
 
 Boundary::Boundary(Line const line)
 {
 	m_line = line;
 	m_color = RandomColor();
-	m_sample_points = Array<SamplePoint>();
 }
 
 Line Boundary::getLine() const
@@ -15,20 +13,9 @@ Line Boundary::getLine() const
 	return m_line;
 }
 
-Array<SamplePoint>& Boundary::getSamplePoints()
+Color Boundary::getColor() const
 {
-	return m_sample_points;
-}
-
-void Boundary::addSamplePoint(Vec2 pos)
-{
-	SamplePoint sample(pos);
-	m_sample_points << sample;
-}
-
-void Boundary::addSamplePoint(SamplePoint& sample)
-{
-	m_sample_points << sample;
+	return m_color;
 }
 
 void Boundary::setColor(Color color)
@@ -36,10 +23,7 @@ void Boundary::setColor(Color color)
 	m_color = color;
 }
 
-void Boundary::draw()
+void Boundary::draw() const
 {
-	for (auto& sample : m_sample_points) {
-		sample.draw(m_color);
-	}
 	m_line.draw(4, m_color);
 }

--- a/BSH-Siv3D/Boundary.hpp
+++ b/BSH-Siv3D/Boundary.hpp
@@ -1,21 +1,17 @@
 ﻿#pragma once
 
 # include <Siv3D.hpp>
-# include "SamplePoint.hpp"
 
 class Boundary
 {
 	private:
 		Line m_line;
-		Array<SamplePoint> m_sample_points;
 		Color m_color;
 
 	public:
 		Boundary(Line const line);
 		Line getLine() const;
-		Array<SamplePoint>& getSamplePoints();
-		void addSamplePoint(Vec2 pos);
-		void addSamplePoint(SamplePoint& sample);
+		Color getColor() const;
 		void setColor(Color color);
-		void draw();
+		void draw() const;
 };

--- a/BSH-Siv3D/Boundary.hpp
+++ b/BSH-Siv3D/Boundary.hpp
@@ -9,7 +9,7 @@ class Boundary
 		Color m_color;
 
 	public:
-		Boundary(Line const line);
+		Boundary(Vec2 begin, Vec2 end, Vec2 sceneSize);
 		Line getLine() const;
 		Color getColor() const;
 		void setColor(Color color);

--- a/BSH-Siv3D/HalfSpace.cpp
+++ b/BSH-Siv3D/HalfSpace.cpp
@@ -1,0 +1,92 @@
+﻿#include "stdafx.h"
+#include "HalfSpace.hpp"
+
+void HalfSpace::sort()
+{
+	// 重心を計算
+	Vec2 g = m_vertices.sum() / m_vertices.size();
+	// 交点が時計回りに並ぶように極座標で整列
+	std::sort(m_vertices.begin(), m_vertices.end(), [g](auto const& left, auto const& right) {
+		return std::atan2((left - g).y, (left - g).x) < std::atan2((right - g).y, (right - g).x);
+	});
+}
+
+Array<HalfSpace> HalfSpace::divideBySample(HalfSpace parent, SamplePoint sample)
+{
+	Array<HalfSpace> halfSpaces = Array<HalfSpace>();
+	Line l = sample.getBoundary().getLine();
+	Polygon parentPolygon = parent.getPolygon();
+	auto intersections = l.intersectsAt(parentPolygon);
+	Array<Vec2> upperSide = intersections.value();
+	Array<Vec2> lowerSide = intersections.value();
+	for (auto& v : parent.getVertices()) {
+		Line toPoint = Line(0, 0, v.x, v.y);
+		if (toPoint.hasLength() && toPoint.intersects(l)) {
+			lowerSide << v;
+		}
+		else {
+			upperSide << v;
+		}
+	}
+	Array<SamplePoint> upperSamples = Array<SamplePoint>();
+	upperSamples << sample;
+	Array<SamplePoint> lowerSamples = Array<SamplePoint>();
+	lowerSamples << sample;
+
+	for (auto& s : parent.getSamples()) {
+		Line toPoint = Line(0, 0, s.getPos().x, s.getPos().y);
+		if (toPoint.intersects(l)) {
+			lowerSamples << s;
+		}
+		else {
+			upperSamples << s;
+		}
+	}
+	Vec2 samplePos = Vec2(sample.getPos().x + Math::Cos(sample.getDirection()), sample.getPos().y + Math::Sin(sample.getDirection()));
+	Line toSample = Line(0, 0, samplePos.x, samplePos.y);
+	Array<SamplePoint> samples = parent.getSamples();
+	samples << sample;
+	if (toSample.intersects(l)) {
+		halfSpaces << HalfSpace(lowerSamples, lowerSide, false);
+		halfSpaces << HalfSpace(upperSamples, upperSide, true);
+	}
+	else {
+		halfSpaces << HalfSpace(lowerSamples, lowerSide, true);
+		halfSpaces << HalfSpace(upperSamples, upperSide, false);
+	}
+	return halfSpaces;
+}
+
+HalfSpace::HalfSpace(Array<SamplePoint> samplePoints, Array<Vec2> vertices, bool inside)
+{
+	m_samples = samplePoints;
+	m_vertices = vertices;
+	is_inside = inside;
+	sort();
+}
+
+Polygon HalfSpace::getPolygon() const
+{
+	return Polygon(m_vertices);
+}
+
+Array<Vec2> HalfSpace::getVertices() const
+{
+	return m_vertices;
+}
+
+Array<SamplePoint> HalfSpace::getSamples() const
+{
+	return m_samples;
+}
+
+void HalfSpace::draw() const
+{
+	Print << m_vertices << is_inside;
+
+	if (is_inside)
+	{
+		// ポリゴンを描画
+		Polygon(m_vertices).draw(Palette::Red);
+	}
+}

--- a/BSH-Siv3D/HalfSpace.cpp
+++ b/BSH-Siv3D/HalfSpace.cpp
@@ -70,6 +70,11 @@ Polygon HalfSpace::getPolygon() const
 	return Polygon(m_vertices);
 }
 
+void HalfSpace::setInside(bool inside)
+{
+	is_inside = inside;
+}
+
 Array<Vec2> HalfSpace::getVertices() const
 {
 	return m_vertices;
@@ -82,7 +87,7 @@ Array<SamplePoint> HalfSpace::getSamples() const
 
 void HalfSpace::draw() const
 {
-	Print << m_vertices << is_inside;
+	//Print << m_vertices << is_inside;
 
 	if (is_inside)
 	{

--- a/BSH-Siv3D/HalfSpace.hpp
+++ b/BSH-Siv3D/HalfSpace.hpp
@@ -1,0 +1,20 @@
+﻿#pragma once
+#include "SamplePoint.hpp"
+class HalfSpace
+{
+	private:
+		Array<SamplePoint> m_samples;
+		Array<Vec2> m_vertices;
+		bool is_inside;
+
+		void sort();
+
+	public:
+		static Array<HalfSpace> divideBySample(HalfSpace parent, SamplePoint sample);
+		HalfSpace(Array<SamplePoint> samplePoints, Array<Vec2> vertices, bool inside);
+		Polygon getPolygon() const;
+		Array<Vec2> getVertices() const;
+		Array<SamplePoint> getSamples() const;
+		void draw() const;
+};
+

--- a/BSH-Siv3D/HalfSpace.hpp
+++ b/BSH-Siv3D/HalfSpace.hpp
@@ -12,6 +12,7 @@ class HalfSpace
 	public:
 		static Array<HalfSpace> divideBySample(HalfSpace parent, SamplePoint sample);
 		HalfSpace(Array<SamplePoint> samplePoints, Array<Vec2> vertices, bool inside);
+		void setInside(bool inside);
 		Polygon getPolygon() const;
 		Array<Vec2> getVertices() const;
 		Array<SamplePoint> getSamples() const;

--- a/BSH-Siv3D/Main.cpp
+++ b/BSH-Siv3D/Main.cpp
@@ -1,7 +1,7 @@
 ﻿# include <Siv3D.hpp> // OpenSiv3D v0.6.4
 # include "Boundary.hpp"
 # include "SamplePoint.hpp"
-#include "State.h"
+# include "State.h"
 
 SamplePoint* findSamplePoint(Array<SamplePoint>& samplePoints)
 {
@@ -97,8 +97,7 @@ void Main()
 				if (MouseL.down())
 				{
 					// 左クリックで境界を決定
-					Line l = Line(startPos, Cursor::Pos());
-					Boundary b = Boundary(l);
+					Boundary b = Boundary(startPos, Cursor::Pos(), Scene::Size());
 					boundaries << b;
 					state = State::none;
 				}

--- a/BSH-Siv3D/Main.cpp
+++ b/BSH-Siv3D/Main.cpp
@@ -40,24 +40,41 @@ SamplePoint* checkIntersect(HalfSpace halfSpace, Array<SamplePoint>& samplePoint
 	return nullptr;
 }
 
-Array<HalfSpace> setHalfSpaces( Array<SamplePoint> samplePoints, Array<Boundary> boundaries)
+Array<HalfSpace> additionalHalfSpace(Array<HalfSpace>& halfSpaces, Array<SamplePoint> samplePoints)
 {
-	Array<HalfSpace> halfSpaces = Array<HalfSpace>();
-	Array<Vec2> sceneRect = Array{ Vec2(0, 0), Vec2(Scene::Size().x, 0) , Vec2(Scene::Size().x, Scene::Size().y) , Vec2(0, Scene::Size().y) };
-	HalfSpace sceneHalfSpace = HalfSpace(Array<SamplePoint>(), sceneRect, false);
-	halfSpaces << sceneHalfSpace;
+	Array<HalfSpace> newHalfSpaces = Array<HalfSpace>();
 	for (auto it = halfSpaces.begin(); it != halfSpaces.end();)
 	{
 		if (auto s = checkIntersect(*it, samplePoints))
 		{
-			halfSpaces.append(HalfSpace::divideBySample(*it, *s));
+			newHalfSpaces.append(HalfSpace::divideBySample(*it, *s));
+			//(* it).setInside(false);
 			it = halfSpaces.erase(it);
+			return newHalfSpaces;
 		}
 		else
 		{
 			++it;
 		}
 	}
+	return newHalfSpaces;
+
+}
+
+Array<HalfSpace> setHalfSpaces( Array<SamplePoint>& samplePoints, Array<Boundary> boundaries)
+{
+	Array<HalfSpace> halfSpaces = Array<HalfSpace>();
+	Array<Vec2> sceneRect = Array{ Vec2(0, 0), Vec2(Scene::Size().x, 0) , Vec2(Scene::Size().x, Scene::Size().y) , Vec2(0, Scene::Size().y) };
+	HalfSpace sceneHalfSpace = HalfSpace(Array<SamplePoint>(), sceneRect, false);
+	halfSpaces << sceneHalfSpace;
+
+	Array<HalfSpace> newHalfSpaces = additionalHalfSpace(halfSpaces, samplePoints);
+	while (newHalfSpaces.size() > 0)
+	{
+		halfSpaces.append(newHalfSpaces);
+		newHalfSpaces = additionalHalfSpace(halfSpaces, samplePoints);
+	}
+
 	return halfSpaces;
 }
 

--- a/BSH-Siv3D/Main.cpp
+++ b/BSH-Siv3D/Main.cpp
@@ -3,15 +3,13 @@
 # include "SamplePoint.hpp"
 #include "State.h"
 
-SamplePoint* findSamplePoint(Array<Boundary>& boundaries)
+SamplePoint* findSamplePoint(Array<SamplePoint>& samplePoints)
 {
 	// サンプルをクリックで内外方向を変更
-	for (auto& b : boundaries) {
-		for (auto& p : b.getSamplePoints()) {
-			if (p.getCircle().leftClicked())
-			{
-				return &p;
-			}
+	for (auto& p : samplePoints) {
+		if (p.getCircle().leftClicked())
+		{
+			return &p;
 		}
 	}
 	return nullptr;
@@ -36,11 +34,12 @@ void Main()
 	Array<Circle> circles;
 
 	Array<Boundary> boundaries;
+	Array<SamplePoint> samplePoints;
 
-	bool lineOpen = false;
+	State state = State::none;
+
 	SamplePoint* selectedSample = nullptr;
 	Vec2 startPos;
-	State state = State::none;
 
 	while (System::Update())
 	{
@@ -50,7 +49,7 @@ void Main()
 				if (MouseL.down())
 				{
 					// サンプルをクリックで内外方向を変更
-					SamplePoint* clickedPoint = findSamplePoint(boundaries);
+					SamplePoint* clickedPoint = findSamplePoint(samplePoints);
 					if (clickedPoint)
 					{
 						selectedSample = clickedPoint;
@@ -58,11 +57,12 @@ void Main()
 						break;
 					}
 
-					// 境界をクリックで内外方向を変更
+					// 境界をクリックでサンプルポイントを追加
 					Boundary* b = findBoundaryByPos(Cursor::Pos(), boundaries);
 					if (b)
 					{
-						b->addSamplePoint(b->getLine().closest(Cursor::Pos()));
+						SamplePoint newSample(b->getLine().closest(Cursor::Pos()), b);
+						samplePoints << newSample;
 						break;
 					}
 
@@ -133,6 +133,12 @@ void Main()
 		for (auto& b : boundaries)
 		{
 			b.draw();
+		}
+
+		// サンプルを描画
+		for (auto& s : samplePoints)
+		{
+			s.draw();
 		}
 	}
 }

--- a/BSH-Siv3D/SamplePoint.cpp
+++ b/BSH-Siv3D/SamplePoint.cpp
@@ -1,4 +1,5 @@
 ﻿# include "SamplePoint.hpp"
+# include "Boundary.hpp"
 
 //SamplePoint::SamplePoint(Boundary boundary, Vec2 pos)
 //{
@@ -12,9 +13,11 @@
 //	m_handle = Line(pos, pos + Vec2(6 * std::cos(2 * pi / 360 * m_direction), 6 * std::sin(2 * pi / 360 * m_direction));
 //}
 
-SamplePoint::SamplePoint(Vec2 pos)
+SamplePoint::SamplePoint(Vec2 pos, Boundary* boundary)
 {
+	m_boundary = boundary;
 	m_point = Circle(pos, 6);
+	m_color = boundary->getColor();
 	m_direction = 0;
 	m_handle = Line();
 	setHandle();
@@ -48,10 +51,10 @@ void SamplePoint::setHandle()
 	m_handle.set(pos, pos + Vec2(8 * std::cos(m_direction), 8 * std::sin(m_direction)));
 }
 
-void SamplePoint::draw(Color color)
+void SamplePoint::draw()
 {
-	m_handle.draw(2, color);
-	m_point.draw(color);
+	m_handle.draw(2, m_color);
+	m_point.draw(m_color);
 }
 
 void SamplePoint::setPos(Vec2 pos)

--- a/BSH-Siv3D/SamplePoint.cpp
+++ b/BSH-Siv3D/SamplePoint.cpp
@@ -39,6 +39,11 @@ float SamplePoint::getDirection()
 	return m_direction;
 }
 
+Boundary SamplePoint::getBoundary() const
+{
+	return *m_boundary;
+}
+
 void SamplePoint::setDirection(float direction)
 {
 	m_direction = direction;

--- a/BSH-Siv3D/SamplePoint.hpp
+++ b/BSH-Siv3D/SamplePoint.hpp
@@ -1,23 +1,26 @@
 ﻿# pragma once
 # include <Siv3D.hpp>
+# include "Boundary.hpp"
 
 class SamplePoint
 {
 	private:
+		Boundary* m_boundary;
 		Circle m_point;
 		Line m_handle;
+		Color m_color;
 		// 算出可能なので消してもよい
 		float m_direction;
 		float m_t;
 
 	public:
-		SamplePoint( Vec2 pos );
+		SamplePoint( Vec2 pos, Boundary* boundary );
 		Vec2 getPos();
 		Circle getCircle();
 		float getDirection();
 		void setDirection(float direction);
 		void setHandle();
-		void draw(Color color);
+		void draw();
 		void setPos(Vec2 pos);
 		void setDirectionByPos(Vec2 pos);
 };

--- a/BSH-Siv3D/SamplePoint.hpp
+++ b/BSH-Siv3D/SamplePoint.hpp
@@ -18,6 +18,7 @@ class SamplePoint
 		Vec2 getPos();
 		Circle getCircle();
 		float getDirection();
+		Boundary getBoundary() const;
 		void setDirection(float direction);
 		void setHandle();
 		void draw();


### PR DESCRIPTION
- できること
  - 線を引いてサンプルポイントを置くと，ハンドルのない方を塗りつぶす
- できないこと
  - ~~エラーのあるハンドルの向きにすると，ハンドリングされずにそのままセグフォ系エラーで落ちる~~
  - 線を引く→サンプルポイントを置く→線を引く　となぜかサンプルポイントの参照が壊れておかしくなる(線を引く→線を引く→サンプルポイント→サンプルポイントとやると正しく動作)
  - 描画部分のコードのリファクタリング
 
<img width="646" alt="image" src="https://user-images.githubusercontent.com/58587065/176102969-a09aa78d-99e8-4331-ab71-ec247e5b547c.png">
